### PR TITLE
Update homepage for Fractional CTO positioning

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Navigation from '../components/Navigation.astro';
 ---
 
-<Layout title="Davide Mendolia - CTO & Head of Engineering">
+<Layout title="Davide Mendolia - Fractional CTO & Technical Advisor">
     <Navigation />
     
     <!-- Hero Section -->
@@ -11,8 +11,8 @@ import Navigation from '../components/Navigation.astro';
         <div class="container">
             <div class="hero-content fade-in">
                 <h1>Davide Mendolia</h1>
-                <p class="subtitle">Engineering leader turning product vision into scalable systems</p>
-                <p class="tagline">From prototype to Series A, I align technology with business goals.</p>
+                <p class="subtitle">Fractional CTO for seed-to-Series B startups</p>
+                <p class="tagline">I help founders make the right engineering decisions at the right time: from first hire to scalable platform.</p>
                 <div class="cta-buttons">
                     <a href="mailto:contact@davideme.com" class="btn btn-primary">
                         <i class="fas fa-envelope"></i>
@@ -108,6 +108,34 @@ import Navigation from '../components/Navigation.astro';
                     <div class="icon"><i class="fas fa-code-branch"></i></div>
                     <h3>DevOps & Platform Engineering</h3>
                     <p>Build reliable, observable infrastructure. Implement CI/CD, monitoring, and security practices that enable confident, rapid deployment.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- How Engagements Work Section -->
+    <section id="how-engagements-work" class="how-i-help">
+        <div class="container">
+            <h2 class="section-title fade-in">How Engagements Work</h2>
+            <p class="section-subtitle fade-in">I work alongside founders, not above them. Every engagement is shaped around what you actually need right now.</p>
+
+            <div class="help-grid">
+                <div class="help-card fade-in">
+                    <div class="icon"><i class="fas fa-user-tie"></i></div>
+                    <h3>Fractional CTO</h3>
+                    <p>1-2 days per week, ongoing. I embed with your team as a hands-on technical leader: setting architecture direction, running hiring, coaching engineers, unblocking delivery. Best for companies that need senior engineering leadership but aren't ready for a full-time CTO.</p>
+                </div>
+
+                <div class="help-card fade-in">
+                    <div class="icon"><i class="fas fa-clipboard-check"></i></div>
+                    <h3>Technical Advisory</h3>
+                    <p>Focused engagements of 1-8 weeks. Architecture reviews, MVP assessments, technical due diligence for investors, or a second opinion before a critical build decision. Clear scope, clear deliverable.</p>
+                </div>
+
+                <div class="help-card fade-in">
+                    <div class="icon"><i class="fas fa-comments"></i></div>
+                    <h3>Starting Point</h3>
+                    <p>Most engagements begin with a single conversation. No proposals until I understand the problem. <a href="mailto:contact@davideme.com">Get in touch</a></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Changes

- Updated page title and hero subtitle to reflect Fractional CTO positioning
- Revised hero tagline to emphasize support for seed-to-Series B startups
- Added new "How Engagements Work" section with three engagement types:
  - Fractional CTO (1-2 days/week ongoing)
  - Technical Advisory (1-8 week focused engagements)
  - Starting Point (initial consultation process)

## Impact

Improves clarity on service offerings and better aligns homepage messaging with Fractional CTO business model.