### PR TITLE
Add Products section showcasing launched projects

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -14,8 +14,9 @@ const currentPath = Astro.url.pathname;
             <div id="nav-menu" class="nav-menu">
                 <ul class="nav-links">
                     <li><a href="/about" class={currentPath === '/about' ? 'active' : ''}>About</a></li>
-                    <li><a href="/#case-studies">Case Studies</a></li>
                     <li><a href="/#achievements">Achievements</a></li>
+                    <li><a href="/#products">Products</a></li>
+                    <li><a href="/#case-studies">Case Studies</a></li>
                     <li><a href="/articles" class={currentPath.startsWith('/articles') ? 'active' : ''}>Articles</a></li>
                     <li><a href="/#contact">Contact</a></li>
                 </ul>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -187,6 +187,40 @@ import Navigation from '../components/Navigation.astro';
         </div>
     </section>
 
+    <!-- Products -->
+    <section id="products">
+        <div class="container">
+            <h2 class="section-title fade-in">Products</h2>
+            <p class="section-subtitle fade-in">Products I've shipped alongside client work.</p>
+
+            <div class="help-grid">
+                <div class="help-card fade-in">
+                    <div class="icon"><i class="fas fa-shield-alt"></i></div>
+                    <h3>Visus</h3>
+                    <p class="product-tagline">Know who clicks before you trust them.</p>
+                    <p>Link intelligence and fraud detection. Wraps your links with browser fingerprinting and real-time risk scoring to filter bots and bad traffic.</p>
+                    <a href="https://visus.page/" target="_blank" rel="noopener noreferrer" class="product-link">Visit <i class="fas fa-arrow-right"></i></a>
+                </div>
+
+                <div class="help-card fade-in">
+                    <div class="icon"><i class="fas fa-scale-balanced"></i></div>
+                    <h3>License to Build</h3>
+                    <p class="product-tagline">Open-source licenses, by what you're building.</p>
+                    <p>A free cheat sheet that maps OSS license obligations to product types — mobile, web, API, CLI — so teams know which dependencies actually create obligations.</p>
+                    <a href="https://licensetobuild.dev/" target="_blank" rel="noopener noreferrer" class="product-link">Visit <i class="fas fa-arrow-right"></i></a>
+                </div>
+
+                <div class="help-card fade-in">
+                    <div class="icon"><i class="fas fa-lightbulb"></i></div>
+                    <h3>ProductBase</h3>
+                    <p class="product-tagline">From ideas to impact, build what matters.</p>
+                    <p>A home for the unstructured work that happens before you start building software: capture ideas, prioritise with RICE-style scoring, share roadmaps with stakeholders.</p>
+                    <a href="https://productbase.davideme.com/" target="_blank" rel="noopener noreferrer" class="product-link">Visit <i class="fas fa-arrow-right"></i></a>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Case Studies -->
     <section id="case-studies">
         <div class="container">
@@ -327,3 +361,35 @@ import Navigation from '../components/Navigation.astro';
         </div>
     </footer>
 </Layout>
+
+<style>
+    .help-card .product-tagline {
+        color: var(--primary-color);
+        font-weight: 500;
+        font-size: 0.9375rem;
+        margin-bottom: 0.75rem;
+        letter-spacing: -0.01em;
+    }
+
+    .product-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin-top: 1.25rem;
+        color: var(--accent-color);
+        font-size: 0.875rem;
+        font-weight: 500;
+        letter-spacing: -0.01em;
+        text-decoration: none;
+        transition: gap 0.2s ease, color 0.2s ease;
+    }
+
+    .product-link:hover {
+        color: var(--accent-hover);
+        gap: 0.6rem;
+    }
+
+    .product-link i {
+        font-size: 0.75rem;
+    }
+</style>


### PR DESCRIPTION
## Summary
- Adds a new **Products** section to the homepage between *Key Achievements* and *Featured Case Studies*, highlighting three personal products: **Visus** (visus.page), **License to Build** (licensetobuild.dev), and **ProductBase** (productbase.davideme.com).
- Adds a matching **Products** link in the top nav and swaps the Achievements/Case Studies order so the nav mirrors the on-page order: *About · Achievements · Products · Case Studies · Articles · Contact*.
- Reuses the existing `.help-grid` / `.help-card` pattern from `Layout.astro` — no new layout primitives. Only a small scoped `<style>` block in `index.astro` adds a `.product-tagline` and a `.product-link` ("Visit →") affordance.

## Why
These are launched products built outside of client work. Surfacing them on the Fractional CTO landing page is a credibility signal (advisor *and* builder) that wasn't visible before. Placing it between Achievements (client outcomes) and Case Studies (deep dives) groups all "proof of work" together.

## Notes for the reviewer
- The Visus card uses `fa-shield-alt` rather than `fa-shield-halved`. The site loads `font-awesome/6.0.0/css/all.min.css`, which doesn't ship the renamed glyph reliably — `fa-shield-alt` renders the same shield correctly.
- All three "Visit" links open in a new tab with `rel="noopener noreferrer"`.
- No new image assets, no new components, no Layout.astro changes.

## Test plan
- [x] Desktop (1280px): three cards render in a row between Achievements and Case Studies.
- [x] Mobile (375px): cards collapse to a single column via the existing `help-grid` breakpoint.
- [x] Light + dark mode both look correct (icons, card bg, "Visit →" colour adapt via existing CSS vars).
- [x] All three "Visit" links carry `target="_blank"` + `rel="noopener noreferrer"`.
- [x] Nav `Products` link smooth-scrolls to `#products` (uses existing `html { scroll-behavior: smooth }`).
- [x] `npm run build` passes — 23 pages built, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)