### PR TITLE
chore: limit GitHub Actions Dependabot updates to major versions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,5 +45,10 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     cooldown:
       default-days: 5


### PR DESCRIPTION
## Summary

- Added `ignore` rules to the `github-actions` Dependabot configuration to skip `semver-minor` and `semver-patch` updates for all dependencies
- Dependabot will now only open PRs for GitHub Actions when there is a major version bump

## Why

Minor and patch updates to GitHub Actions (e.g. `actions/checkout@v6` → `v6.0.2`) add noise without meaningful risk changes. Major version bumps are the ones that may introduce breaking changes and warrant explicit review.

## Reviewer notes

This does not affect the `npm` ecosystem configuration — that remains unchanged with full semver tracking.