### PR TITLE
feat: switch Industry Usage from percentages to rankings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md
+
+## URL patterns
+
+Articles live under two routes depending on publish state:
+
+- **Published:** `/articles/[id]` — e.g. `/articles/frontend-framework-saas`
+- **Draft:** `/drafts/[id]` — e.g. `/drafts/frontend-framework-saas`
+
+The `[id]` matches the filename of the `.mdx` file in `src/data/articles/`.
+Drafts are accessible by direct link only; they do not appear in the public articles listing.

--- a/src/components/advisor/AdoptionBar.astro
+++ b/src/components/advisor/AdoptionBar.astro
@@ -16,12 +16,11 @@ const metaFw = metaKey ? advisorData.meta[metaKey] : null;
 
 const pct = fw.usage;
 const AB_MAX = 30;
-const AB_TICKS = [5, 10, 20, 30];
 const width = Math.min(100, (pct / AB_MAX) * 100);
 
 const srLabel = metaFw
-  ? `${metaFw.name} is built on ${fw.name} (${pct}% usage)`
-  : `Industry adoption — ${fw.name} ${pct}% (Stack Overflow Survey 2025)`;
+  ? `${metaFw.name} is built on ${fw.name} (${fw.usageRank} industry adoption)`
+  : `Industry adoption — ${fw.name} ${fw.usageRank} (Stack Overflow Survey 2025)`;
 const note = metaFw
   ? `${metaFw.name} shares ${fw.name}'s adoption — ${fw.usageNote.toLowerCase()}`
   : fw.usageNote;
@@ -33,13 +32,9 @@ const note = metaFw
     {!compact && <span class="adopt__src">Stack Overflow '25</span>}
   </div>
   <div class="adopt__track" aria-hidden="true">
-    {AB_TICKS.map(tk => <span class="adopt__tick" style={`left:${(tk / AB_MAX) * 100}%`}></span>)}
     <div class="adopt__fill" data-width={width} style={`width:0%;background:${fw.brand}`}>
-      <span class="adopt__pct" style="color:#fff">{pct}%</span>
+      <span class="adopt__pct" style="color:#fff">{fw.usageRank}</span>
     </div>
-  </div>
-  <div class="adopt__ticks" aria-hidden="true">
-    {AB_TICKS.map(tk => <span class="adopt__ticklbl" style={`left:${(tk / AB_MAX) * 100}%`}>{tk}%</span>)}
   </div>
   <p class="adopt__note">
     {metaFw
@@ -62,18 +57,12 @@ const note = metaFw
     position: relative; height: 14px; border-radius: 980px;
     background: var(--bg-2); border: 1px solid var(--border-1); overflow: hidden;
   }
-  .adopt__tick { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--border-1); z-index: 1; }
   .adopt__fill {
     position: relative; height: 100%; border-radius: 980px; z-index: 2;
     transition: width .42s cubic-bezier(.2,.7,.2,1);
     display: flex; align-items: center; justify-content: flex-end; min-width: 30px;
   }
   .adopt__pct { font-size: 10px; font-weight: 700; padding-right: 8px; font-variant-numeric: tabular-nums; }
-  .adopt__ticks { position: relative; height: 13px; }
-  .adopt__ticklbl {
-    position: absolute; top: 0; transform: translateX(-50%); font-size: 10px;
-    color: var(--fg-3); font-variant-numeric: tabular-nums;
-  }
   .adopt__note { font-size: var(--fs-2xs); color: var(--fg-3); line-height: 1.45; margin: 0; }
   @media (prefers-reduced-motion: reduce) { .adopt__fill { transition: none; } }
   .adopt--compact .adopt__track { height: 11px; }

--- a/src/data/articles/frontend-framework-saas.mdx
+++ b/src/data/articles/frontend-framework-saas.mdx
@@ -46,13 +46,13 @@ A **meta framework** (Next.js, Nuxt, SvelteKit) wraps a frontend framework and a
 
 Sources: [Stack Overflow Survey](https://survey.stackoverflow.co/2025/technology#1-web-frameworks-and-technologies) and [State of JS](https://2025.stateofjs.com/en-US/libraries/front-end-frameworks/#front_end_frameworks_ratios).
 
-| Framework | Current Usage | Developer Enthusiasm          |
-| --------- | ------------- | ----------------------------- |
-| React     | 30%           | Declining year over year      |
-| Vue.js    | 19%           | Most stable among the leaders |
-| Angular   | 17%           | Declining year over year      |
-| Svelte    | 10%           | High desire, rising           |
-| Solid     | 3.8%          | Highest desire ranking        |
+| Framework | Rank | Developer Enthusiasm          |
+| --------- | ---- | ----------------------------- |
+| React     | #1   | Declining year over year      |
+| Vue.js    | #2 (tied) | Most stable among the leaders |
+| Angular   | #2 (tied) | Declining year over year      |
+| Svelte    | #4   | High desire, rising           |
+| Solid     | #5   | Highest desire ranking        |
 
 React and Angular are losing developer enthusiasm year over year. Vue holds its position most consistently. Solid and Svelte top the "want to work with" rankings and score the highest developer satisfaction in surveys, loved for their simplicity and low boilerplate, but remain niche in actual adoption. Angular scores lower on satisfaction but higher on perceived reliability and structure.
 

--- a/src/data/framework-advisor.yaml
+++ b/src/data/framework-advisor.yaml
@@ -11,7 +11,8 @@ frameworks:
     name: React
     brand: "#087EA4"
     usage: 30
-    usageNote: "30% — the largest talent pool of any frontend framework."
+    usageRank: "#1"
+    usageNote: "#1 — the largest talent pool of any frontend framework."
     backing: Backed by Meta
     backingNote: Run in Meta's own products at scale.
     ecosystem: First-class official SDKs for auth, billing, and UI.
@@ -31,7 +32,8 @@ frameworks:
     name: Vue
     brand: "#42B883"
     usage: 19
-    usageNote: "19% — steady adoption with the gentlest learning curve."
+    usageRank: "#2 (tied)"
+    usageNote: "#2 (tied) — steady adoption with the gentlest learning curve."
     backing: Led by Evan You
     backingNote: Independent, funded via VoidZero / Cloudflare tooling.
     ecosystem: "Official SDKs for the major tools; shadcn-vue is growing."
@@ -51,7 +53,8 @@ frameworks:
     name: Angular
     brand: "#DD0031"
     usage: 17
-    usageNote: "17% — entrenched in enterprise, built for the long haul."
+    usageRank: "#2 (tied)"
+    usageNote: "#2 (tied) — entrenched in enterprise, built for the long haul."
     backing: Backed by Google
     backingNote: Run in Google's own products at scale.
     ecosystem: Official SDKs plus first-party Angular Material.
@@ -71,7 +74,8 @@ frameworks:
     name: Svelte
     brand: "#FF3E00"
     usage: 10
-    usageNote: "10% — beloved by builders, but a smaller hiring pool."
+    usageRank: "#4"
+    usageNote: "#4 — beloved by builders, but a smaller hiring pool."
     backing: Rich Harris, employed by Vercel
     backingNote: A full-time principal contributor, not a large company.
     ecosystem: "Official Sentry SDK; community adapters for auth & billing."
@@ -91,7 +95,8 @@ frameworks:
     name: Solid
     brand: "#2C4F7C"
     usage: 3.8
-    usageNote: "3.8% — enthusiast favourite, limited hiring pool."
+    usageRank: "#5"
+    usageNote: "#5 — enthusiast favourite, limited hiring pool."
     backing: Community-driven
     backingNote: "No corporate backer, small core team."
     ecosystem: Works at the JS-SDK layer; you wrap integrations yourself.


### PR DESCRIPTION
## Summary

- Replaces the \"Current Usage %\" column in the Industry Usage (2025) table with ordinal **Rank** values (`#1`, `#2 (tied)`, `#4`, `#5`), sourced from Stack Overflow Survey and State of JS
- Vue.js and Angular are both shown as `#2 (tied)` to make the tie explicit and avoid it looking like a mistake
- The adoption bar in the **Framework Advisor widget** now displays the rank badge (e.g. `#1`) inside the fill instead of a percentage, and the percentage axis tick labels are removed since they no longer apply to a ranking metric
- Adds `CLAUDE.md` documenting the article vs. draft URL patterns (`/articles/[id]` and `/drafts/[id]`)

## Test plan

- [ ] Check the Industry Usage table in the article renders `#1`, `#2 (tied)`, `#2 (tied)`, `#4`, `#5`
- [ ] Complete the Framework Advisor questionnaire and confirm the adoption bar shows the rank badge with no percentage labels on the axis
- [ ] Verify Vue and Angular both show `#2 (tied)` in the widget result cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)