### PR TITLE
fix: update site URL to davideme.com

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ import { unified, rehypeHeadingIds } from '@astrojs/markdown-remark';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://davideme.dev',
+  site: 'https://davideme.com',
   markdown: {
     processor: unified({
       rehypePlugins: [


### PR DESCRIPTION
## Summary
- Corrects the site URL in `astro.config.mjs` from `https://davideme.dev` to `https://davideme.com`
- Ensures the sitemap and all generated absolute URLs reference the correct domain

## Test plan
- [ ] Verify sitemap at `/sitemap-index.xml` references `davideme.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)